### PR TITLE
Add hex round trip color test

### DIFF
--- a/TeaElephantEditorTests/TeaElephantEditorTests.swift
+++ b/TeaElephantEditorTests/TeaElephantEditorTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+import SwiftUI
 @testable import TeaElephantEditor
 
 class TeaElephantEditorTests: XCTestCase {
@@ -28,6 +29,12 @@ class TeaElephantEditorTests: XCTestCase {
         self.measure {
             // Put the code you want to measure the time of here.
         }
+    }
+
+    func testColorHexRoundTrip() throws {
+        let expected = "#FF336699"
+        let color = Color(hex: expected)
+        XCTAssertEqual(color.hex(), expected)
     }
 
 }


### PR DESCRIPTION
## Summary
- verify `Color` hex string roundtrip for ARGB values

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -scheme TeaElephantEditor` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684734a602b88325b66e56f0b0a28c34